### PR TITLE
Remove 512-byte limit of message size

### DIFF
--- a/library/Pushy/Client.php
+++ b/library/Pushy/Client.php
@@ -152,7 +152,7 @@ class Client
     /**
      * Cancel emergency
      *
-     * @param $string $receipt Receipt Id
+     * @param string $receipt Receipt Id
      *
      * @return bool True if canceled
      */

--- a/library/Pushy/Message.php
+++ b/library/Pushy/Message.php
@@ -129,13 +129,6 @@ class Message
      */
     public function setMessage($message)
     {
-        // Message must be of valid length
-        if (strlen($message) > 512) {
-            throw new \InvalidArgumentException(
-                'Message may not exceed 512 characters'
-            );
-        }
-
         $this->message = (string) $message;
 
         return $this;

--- a/library/Pushy/Priority/EmergencyPriority.php
+++ b/library/Pushy/Priority/EmergencyPriority.php
@@ -116,6 +116,7 @@ class EmergencyPriority extends AbstractPriority
      * Set callback URL
      *
      * @param string $url Callback URL
+     * @return $this
      */
     public function setCallback($url)
     {

--- a/library/Pushy/Priority/PriorityFactory.php
+++ b/library/Pushy/Priority/PriorityFactory.php
@@ -20,6 +20,7 @@ class PriorityFactory
      * @param string $name Priority name
      *
      * @return AbstractPriority Priority
+     * @throws \Exception
      */
     public static function createPriority($name)
     {

--- a/library/Pushy/Transport/Http.php
+++ b/library/Pushy/Transport/Http.php
@@ -41,7 +41,11 @@ class Http extends AbstractTransport
     /**
      * Send request
      *
+     * @param RequestMessage $requestMessage
+     *
      * @return array Response data
+     * @throws ApiException
+     * @throws ConnectionException
      */
     public function sendRequest(RequestMessage $requestMessage)
     {

--- a/library/Pushy/Transport/RequestMessage.php
+++ b/library/Pushy/Transport/RequestMessage.php
@@ -60,7 +60,9 @@ class RequestMessage
     /**
      * Set request method
      *
-     * @return self This object
+     * @param string $method
+     *
+     * @return RequestMessage This object
      */
     public function setMethod($method)
     {
@@ -82,7 +84,9 @@ class RequestMessage
     /**
      * Set request path
      *
-     * @return self This object
+     * @param string $path
+     *
+     * @return RequestMessage This object
      */
     public function setPath($path)
     {

--- a/library/Pushy/User.php
+++ b/library/Pushy/User.php
@@ -54,7 +54,7 @@ class User
     /**
      * Set user Id
      *
-     * @param string $key User key
+     * @param string $id User id
      *
      * @return self This object
      */

--- a/tests/Pushy/Test/MessageTest.php
+++ b/tests/Pushy/Test/MessageTest.php
@@ -108,18 +108,6 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test: Set invalid length message
-     *
-     * @covers \Pushy\Message::setMessage
-     *
-     * @expectedException \InvalidArgumentException
-     */
-    public function testSetMessageWithInvalidLength()
-    {
-        $this->message->setMessage(str_repeat('X', 513));
-    }
-
-    /**
      * Test: Get/Set title
      *
      * @covers \Pushy\Message::getTitle


### PR DESCRIPTION
The api states "Messages are currently limited to 1024 4-byte UTF-8 characters, with a title of up to 250 characters."

So i removed the artificial message length restriction from the client.
I would much rather get a message from pushover.net with a truncated end, than get a exception from pushover saying i cant send the message (without the message i needed to have sent),   (yes, i use pushover in my exception handler too).

Also corrected some minor phpdoc details