### PR TITLE
Posibility to set multiple devices for one user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 .DS_Store
+.idea/

--- a/library/Pushy/User.php
+++ b/library/Pushy/User.php
@@ -38,7 +38,10 @@ class User
     {
         // Set user Id and device
         $this->setId($id);
-        $this->setDeviceName($deviceName);
+        
+        if ($deviceName) {
+            $this->setDeviceName($deviceName);
+        }
     }
 
     /**

--- a/library/Pushy/User.php
+++ b/library/Pushy/User.php
@@ -24,9 +24,9 @@ class User
     /**
      * User's device name
      *
-     * @var string
+     * @var array
      */
-    protected $deviceName;
+    protected $deviceName = array();
 
     /**
      * Instantiate a user object
@@ -79,7 +79,7 @@ class User
      */
     public function getDeviceName()
     {
-        return $this->deviceName;
+        return implode(',', $this->deviceName);
     }
 
     /**
@@ -98,8 +98,10 @@ class User
                 . ' and contain character set [A-Za-z0-9-]'
             );
         }
-
-        $this->deviceName = (string) $deviceName;
+    
+        if (!in_array($deviceName, $this->deviceName)) {
+            $this->deviceName[] = (string) $deviceName;
+        }
 
         return $this;
     }

--- a/tests/Pushy/Test/UserTest.php
+++ b/tests/Pushy/Test/UserTest.php
@@ -76,6 +76,23 @@ class UserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test: Get/Set Multiple Device Name
+     *
+     * @covers \Pushy\User::getDeviceName
+     * @covers \Pushy\User::setDeviceName
+     */
+    public function testGetSetMultipleDeviceName()
+    {
+        $deviceName = 'test-device';
+        $deviceName2 = 'my-test';
+
+        $this->user->setDeviceName($deviceName)
+                   ->setDeviceName($deviceName2);
+
+        $this->assertEquals($deviceName . ',' . $deviceName2, $this->user->getDeviceName());
+    }
+
+    /**
      * Test: Set device name with an invalid value
      *
      * @covers \Pushy\User::setDeviceName


### PR DESCRIPTION
[PushOver API "Users, Groups, and Devices"](https://pushover.net/api#identifiers) states that:
> Messages may be addressed to multiple specific devices by joining them with a comma (such as device=iphone,nexus5).

Right now if you use `->setDeviceName('iphone,nexus5')` you get an exception `Device name must be no more than 25 characters long and contain character set [A-Za-z0-9-]`. This PR fixes it. Now you can use:
```php
$user = new User('myID', 'motorola');
$user->setDeviceName('iphone')
     ->setDeviceName('nexus5');

echo $user->getDeviceName(); // prints 'motorola,iphone,nexus5'
```

A device that is not correct still throws an exception:
```php
$user = new User('myID', 'motorola-over-25-characters');

// Exception: Device name must be no more than 25 characters long and contain character set [A-Za-z0-9-]
```